### PR TITLE
Allow python -m blend2bam to work

### DIFF
--- a/blend2bam/__main__.py
+++ b/blend2bam/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()


### PR DESCRIPTION
I intuitively expected `python -m blend2bam` to work.  This enables that.