### PR TITLE
blend2gltf: fix syntax error with older Python versions

### DIFF
--- a/blend2bam/blend2gltf/blender_script.py
+++ b/blend2bam/blend2gltf/blender_script.py
@@ -7,7 +7,7 @@ import bpy #pylint: disable=import-error
 def make_particles_real():
     for obj in bpy.data.objects[:]:
         if hasattr(obj, 'particle_systems'):
-            print(f'Making particles on {obj.name} real')
+            print('Making particles on {} real'.format(obj.name))
             obj.select = True
             bpy.ops.object.duplicates_make_real()
 


### PR DESCRIPTION
The binary builds of Blender 2.79 ship with Python 3.5, so f-strings may not be used.