### PR TITLE
Indicate support for shape key animations via gltf28 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,15 @@ The below table hightlights some of the differences.
 |Lights|:heavy_check_mark:|:x:|:heavy_check_mark:|
 |Skinned Meshes|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Skeletal Animations|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|Shape Keys|:x:|:heavy_check_mark:|:x:|
-|Shape Key Animations|:x:|:heavy_check_mark:|:x:|
+|Shape Keys|:x:|:heavy_check_mark:|:heavy_check_mark:|
+|Shape Key Animations|:x:|:heavy_check_mark:|:heavy_check_mark:<sup>1</sup>|
 |CollisionSolids|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 |Bullet Shapes|:heavy_check_mark:|:x:|:heavy_check_mark:|
 |Tags from Game Properties|:heavy_check_mark:|:heavy_check_mark:|:x:|
 |Tags from Custom Properties|:heavy_check_mark:|:x:|:heavy_check_mark:|
 |Convert Particle Systems to Meshes|:heavy_check_mark:|:x:|:heavy_check_mark:|
 
+<sup>1</sup> Shape key animations require Panda3D 1.10.6.
 
 ## License
 


### PR DESCRIPTION
With a footnote indicating that Panda3D 1.10.6 is required for shape key animations.