### PR TITLE
Fix gltf2bam not using blender_dir

### DIFF
--- a/blend2bam/gltf2bam/__init__.py
+++ b/blend2bam/gltf2bam/__init__.py
@@ -18,8 +18,8 @@ class ConverterGltf2Bam(ConverterBase):
             'textures': self.settings.textures,
         }
 
-        if blenderutils.is_blender_28(self.settings.blender_dir) and \
-           self.settings.material_mode == 'legacy':
+        if self.settings.material_mode == 'legacy' and \
+           blenderutils.is_blender_28(self.settings.blender_dir):
             gltf2bam_version = [int(i) for i in gltf.__version__.split('.')]
             if gltf2bam_version[0] == 0 and gltf2bam_version[1] < 9:
                 raise RuntimeError(

--- a/blend2bam/gltf2bam/__init__.py
+++ b/blend2bam/gltf2bam/__init__.py
@@ -18,7 +18,7 @@ class ConverterGltf2Bam(ConverterBase):
             'textures': self.settings.textures,
         }
 
-        if blenderutils.is_blender_28(settings.blender_dir) and self.settings.material_mode == 'legacy':
+        if blenderutils.is_blender_28(self.settings.blender_dir) and self.settings.material_mode == 'legacy':
             gltf2bam_version = [int(i) for i in gltf.__version__.split('.')]
             if gltf2bam_version[0] == 0 and gltf2bam_version[1] < 9:
                 raise RuntimeError(

--- a/blend2bam/gltf2bam/__init__.py
+++ b/blend2bam/gltf2bam/__init__.py
@@ -18,7 +18,8 @@ class ConverterGltf2Bam(ConverterBase):
             'textures': self.settings.textures,
         }
 
-        if blenderutils.is_blender_28(self.settings.blender_dir) and self.settings.material_mode == 'legacy':
+        if blenderutils.is_blender_28(self.settings.blender_dir) and \
+           self.settings.material_mode == 'legacy':
             gltf2bam_version = [int(i) for i in gltf.__version__.split('.')]
             if gltf2bam_version[0] == 0 and gltf2bam_version[1] < 9:
                 raise RuntimeError(

--- a/blend2bam/gltf2bam/__init__.py
+++ b/blend2bam/gltf2bam/__init__.py
@@ -18,7 +18,7 @@ class ConverterGltf2Bam(ConverterBase):
             'textures': self.settings.textures,
         }
 
-        if blenderutils.is_blender_28() and self.settings.material_mode == 'legacy':
+        if blenderutils.is_blender_28(settings.blender_dir) and self.settings.material_mode == 'legacy':
             gltf2bam_version = [int(i) for i in gltf.__version__.split('.')]
             if gltf2bam_version[0] == 0 and gltf2bam_version[1] < 9:
                 raise RuntimeError(


### PR DESCRIPTION
This is a regression in 5241a16c5809ce87447665b44ee3c849f0e147e1 that prevents blend2bam from working on Windows.

I also changed the order of the comparison in the `if` to allow short-circuiting the more expensive/fragile check.

Sorry for the messy PR, I'm doing this from the web client--you're going to need to squash merge this.