### PR TITLE
Fix loader hook not locating Blender on Windows

### DIFF
--- a/blend2bam/loader.py
+++ b/blend2bam/loader.py
@@ -4,6 +4,7 @@ import panda3d.core as p3d
 
 from .cli import convert
 from .common import Settings
+from . import blenderutils
 
 class BlendLoader:
     # Loader metadata
@@ -16,11 +17,16 @@ class BlendLoader:
 
     @staticmethod
     def load_file(path, options, _record=None):
+        settings = BlendLoader.global_settings
+        if not settings.blender_dir and not blenderutils.blender_exists():
+            blender_dir = blenderutils.locate_blenderdir()
+            settings = settings._replace(blender_dir=blender_dir)
+
         loader = p3d.Loader.get_global_ptr()
         with tempfile.NamedTemporaryFile(suffix='.bam') as bamfile:
             bamfilepath = p3d.Filename.from_os_specific(bamfile.name)
             bamfilepath.make_true_case()
-            convert(BlendLoader.global_settings,
+            convert(settings,
                     path.get_dirname(),
                     [path],
                     bamfilepath.to_os_specific())


### PR DESCRIPTION
Fixes #38