### PR TITLE
Don't load temporary bam file through bam cache

### DIFF
--- a/blend2bam/loader.py
+++ b/blend2bam/loader.py
@@ -30,4 +30,7 @@ class BlendLoader:
                     path.get_dirname(),
                     [path],
                     bamfilepath.to_os_specific())
+
+            options = p3d.LoaderOptions(options)
+            options.flags |= p3d.LoaderOptions.LF_no_cache
             return loader.load_sync(bamfilepath, options=options)


### PR DESCRIPTION
I am still investigating the Panda bug that's going on in #44, but I did discover in the process that the bam cache is being consulted and written to an extra time, when loading the temporary file.

Since the temporary bam file is always fresh and always deleted straight afterwards, there is no benefit to be gained from caching it, and indeed disabling the cache for this call appears to be enough to work around the issue in #44.

I think the reason this fixes the issue is because when loading through the RAM cache an extra copy is always created of the entire model, and this causes issues when resolving the light NodePath, because the light NodePath is pointing to a different copy.

Fixes #44