### PR TITLE
Fix error exporting images whose name doesn't match filename

### DIFF
--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -74,18 +74,20 @@ def export_physics(gltf_data):
 
 def fix_image_uri(gltf_data):
     blender_imgs = {
-        i.name.rsplit('.', 1)[0]: i
+        (os.path.basename(i.filepath) or i.name).rsplit('.', 1)[0]: i
         for i in bpy.data.images
     }
     for img in gltf_data.get('images', []):
         blender_img = blender_imgs.get(img['name'], None)
         if blender_img is None:
             print(f'Warning: Failed to find image data for {img["name"]}, skipping')
+            continue
         if blender_img.source == 'FILE':
             filepath = blender_img.filepath
-            if filepath.startswith('//'):
-                filepath = filepath[2:]
-            img['uri'] = filepath
+            if filepath:
+                if filepath.startswith('//'):
+                    filepath = filepath[2:]
+                img['uri'] = filepath
 
 
 def add_actions_to_nla():


### PR DESCRIPTION
Fixes three problems:
* The glTF exporter actually uses the basename of the filepath of the image to determine the name, not the image name, at least as of Blender 2.91
* There's no `continue` after checking if `blender_img is None`, resulting in an exception
* For packed images with an empty `filepath`, the uri was being blanked out—note that this doesn't actually make packed images work, because the actual image file that was generated by the glTF exporter is still nowhere to be found.

I do think the entire concept of fix_image_uri needs to be revisited, because it seems rather fragile even with this change.

Fixes #49