### PR TITLE
Invisible collision geom handling

### DIFF
--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -71,6 +71,11 @@ def export_physics(gltf_data):
             collision_shapes['shapes'][0]['mesh'] = meshref
         gltf_node['extensions']['PANDA3D_physics_collision_shapes'] = collision_shapes
 
+        # Remove the visible mesh from the gltf_node if the object
+        # is in a specific collection
+        if any(list(filter(lambda x:"InvisibleColliders" in x.name, obj.users_collection))):
+            del gltf_node["mesh"]
+
 
 def fix_image_uri(gltf_data):
     blender_imgs = {

--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', ))
 import blender_script_common as common #pylint: disable=import-error,wrong-import-position
 
 
-def export_physics(gltf_data):
+def export_physics(gltf_data, settings):
     gltf_data.setdefault('extensionsUsed', []).append('BLENDER_physics')
 
 
@@ -73,7 +73,8 @@ def export_physics(gltf_data):
 
         # Remove the visible mesh from the gltf_node if the object
         # is in a specific collection
-        if any(list(filter(lambda x:"InvisibleColliders" in x.name, obj.users_collection))):
+        collection = settings['invisible_collisions_collection']
+        if any(list(filter(lambda x:collection in x.name, obj.users_collection))):
             del gltf_node["mesh"]
 
 
@@ -180,7 +181,7 @@ def export_gltf(settings, src, dst):
     with open(dst) as gltf_file:
         gltf_data = json.load(gltf_file)
 
-    export_physics(gltf_data)
+    export_physics(gltf_data, settings)
     if settings['textures'] == 'ref':
         fix_image_uri(gltf_data)
     with open(dst, 'w') as gltf_file:

--- a/blend2bam/cli.py
+++ b/blend2bam/cli.py
@@ -195,6 +195,12 @@ def main():
         help='how to handle animation data'
     )
 
+    parser.add_argument(
+        '--invisible-collisions-collection',
+        default='InvisibleCollisions',
+        help='name of a collection in blender whos collision objects will be exported without a visible geom node'
+    )
+
     args = parser.parse_args()
 
     if args.srcdir:
@@ -237,6 +243,7 @@ def main():
         no_srgb=args.no_srgb,
         textures=args.textures,
         animations=args.animations,
+        invisible_collisions_collection=args.invisible_collisions_collection,
     )
 
     convert(settings, srcdir, src, dst)

--- a/blend2bam/common.py
+++ b/blend2bam/common.py
@@ -10,6 +10,7 @@ Settings = namedtuple('Settings', (
     'no_srgb',
     'textures',
     'animations',
+    'invisible_collisions_collection',
 ))
 Settings.__new__.__defaults__ = (
     'pbr', # material_mode
@@ -21,6 +22,7 @@ Settings.__new__.__defaults__ = (
     'False', # no_srg
     'ref', # textures
     'embed', # animations
+    'InvisibleCollisions', # invisible_collisions_collection
 )
 
 class ConverterBase:


### PR DESCRIPTION
Implementation of exporting invisible collision geometry by adding them to a dedicated, configurable collection in blender.
fixes #46