### PR TITLE
Skip export of objects flagged hide-from-render

### DIFF
--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -148,6 +148,13 @@ def prepare_meshes():
             if modifier.type == 'ARMATURE':
                 continue
 
+def remove_hide_render():
+    # Don't export objects that are hidden for rendering
+    for obj in bpy.data.objects:
+        if obj.hide_render:
+            print(obj.name, 'is hidden from render. Skipping.')
+            bpy.data.objects.remove(obj, do_unlink=True)
+
 def export_gltf(settings, src, dst):
     print('Converting .blend file ({}) to .gltf ({})'.format(src, dst))
 
@@ -158,6 +165,7 @@ def export_gltf(settings, src, dst):
     add_actions_to_nla()
 
     prepare_meshes()
+    remove_hide_render()
 
     bpy.ops.export_scene.gltf(
         filepath=dst,


### PR DESCRIPTION
Some objects can be purely referential or otherwise not intended to be included for conversion. This commit removes them from the scene right before export by disabling its renders visibility. 
![disable](https://user-images.githubusercontent.com/46582649/135484542-cddf6d9a-952e-4409-8358-93fcb4b1f479.png)
