### PR TITLE
enable points and edges on export

### DIFF
--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -170,6 +170,8 @@ def export_gltf(settings, src, dst):
         export_apply=True,
         export_tangents=True,
         export_animations=settings['animations'] != 'skip',
+        use_mesh_edges=True,
+        use_mesh_vertices=True,
     )
 
     with open(dst) as gltf_file:


### PR DESCRIPTION
Blender 2.8's GLTF IO supports export of points and edges and so does panda3d-gltf. Now blend2bam exports them too.

Related: https://github.com/KhronosGroup/glTF-Blender-IO/issues/376