### PR TITLE
Don't delete non-existent mesh node

### DIFF
--- a/blend2bam/blend2gltf/blender28_script.py
+++ b/blend2bam/blend2gltf/blender28_script.py
@@ -74,7 +74,7 @@ def export_physics(gltf_data, settings):
         # Remove the visible mesh from the gltf_node if the object
         # is in a specific collection
         collection = settings['invisible_collisions_collection']
-        if list([x for x in obj.users_collection if x.name == collection]):
+        if list([x for x in obj.users_collection if x.name == collection]) and "mesh" in gltf_node:
             del gltf_node["mesh"]
 
 


### PR DESCRIPTION
If the underlying mesh data is referenced by multiple objects, the first object deletes the referenced mesh data, causing an error when the other instances are encountered.